### PR TITLE
fix(types): Product->google_sku_ids to Record<> (#5)

### DIFF
--- a/src/types/CollectiblesCategories.d.ts
+++ b/src/types/CollectiblesCategories.d.ts
@@ -27,7 +27,7 @@ export interface Product {
 	premium_type: PremiumTypes | number;
 	category_sku_id: string;
 	bundled_products?: BundledProduct[];
-	google_sku_ids: { [key: string]: string } | {};
+	google_sku_ids: Record<string, string | undefined>;
 }
 
 export interface BundledProduct {


### PR DESCRIPTION
The previous type was incorrect and allowed for the value of Product->google_sku_ids to be anything t hat wasn't null or undefined. By using the type `Record<string, string | undefined>` this fixes the issue and appropriately defines the type.

[See the TypeScript Playground for more details](https://www.typescriptlang.org/play/?ts=5.5.3#code/MYewdgzgLgBAJgQygmBeGBtAUDXMDeOexARAOYghkA2ApgPoQDWArvQJZwQkBcBAvgBoiuISILjSFKnUasOXXhOIq8JAKxKSATgCMu7fQBsAdgAcRksNWqSJrXoPGzAJgAsJSXn7ixxQjYw5JQ0DMxsnNx8AYFqmnwkrrom9GZmAMya1rG4dlpJKdomJh5eor7ZuAD0VQTSoXIRXHy6Luk+ALpYWOxgULQATgBmCMC0MACyAJ4AIkgoMdW19bLhChDRGEy0U3zQA71kHXtQB2Bk-DAAPgIwNTAAkmAAbgjUnOL3K2HykZvbuxg+0OxyBp0Ol3uMxAtAgYAA5LAAO4gAZMT7LEKrX7NAhbHYnM5HQkQ64wABKtFAAzgAB5gedBDAwLRnoMAHx3WrQ2EI5Go9HEL5Yn5NDZ4gEk86ghkXMn4SG1ADqAogMAARixYFAABbsNX6vkwakDKmwdVUhAsCDjMAgJEwXW22H9OAwAAOAxA7sGUCmMAQYDdr2oLHGoBY1DdFoDYCmusO4m+jXW-wJYKJMvB5zJLCDtCGvVocEVMBVaLVmtg+ozh1z+cLLLdTo9Xp9AxgSIQ-qgIHgffYUAA-BiYMm1n8KVTUXTZUzZfW4AWi3BOfdy0wIFgfFhQJBtVMfXA5sg+NMTwgMB00PB5gBuIA)